### PR TITLE
Changed iteration over stock prices

### DIFF
--- a/solutions/apple_stock_amelia.rb
+++ b/solutions/apple_stock_amelia.rb
@@ -9,7 +9,7 @@ def max_stock_profit(stock_prices)
 	local_max = stock_prices[1]
 	max_profit_so_far = local_max - local_min
 
-	stock_prices[2..-1].each do |price|
+	stock_prices[1..-1].each do |price|
 
 		if local_max == nil || price > local_max
 			local_max = price


### PR DESCRIPTION
I changed to stock_prices[1..-1] from stock_prices[2..-1] in the rare edge case that the second element is actually lower in value then the first, which would require the local min then to be set to the value of stock_prices[1]. This edge case broke the old code: 

thursday_prices = [13,2,33134,4,5324,6]
